### PR TITLE
Fix two small bugs in the python file IO interface.

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2124,6 +2124,7 @@ class Simulation(object):
         """
         if not dname:
             dname = self.get_filename_prefix() + '-out'
+            self.filename_prefix = ''
 
         closure = {'trashed': False}
 
@@ -2139,8 +2140,7 @@ class Simulation(object):
 
         if self.fields is not None:
             hook()
-        self.filename_prefix = None
-
+       
         return dname
 
     def _run_until(self, cond, step_funcs):
@@ -2638,7 +2638,7 @@ class Simulation(object):
         loaded. This means that they will be *subtracted* from any future field Fourier
         transforms that are accumulated.
         """
-        self.load_near2far(fname, n2f)
+        self.load_near2far(fname, near2far)
         near2far.scale_dfts(-1.0)
 
     def get_near2far_data(self, near2far):


### PR DESCRIPTION
fixes two small bugs.
first a tiny fix for a hard-fail bug: A misnamed variable in load_minus_near2far that lead to an error when called.

Second a small change to `use_output_directory`. The file prefix was being overwritten with 'None' when `use_output_directory` was used.

This was causing issues for me as I wanted to use both a file prefix (specifying simulation parameters) and an output directory (specifying the particular experiment/to keep all the data neatly together) for later analysis.
Because the file prefix was overwritten with `None` the analysis script tried to open `$FOLDER/analysis-$FILE.h5` whereas the simulation script wrote to files `$FOLDER/simulation-$FILE.h5`.

This change sets the filename prefix to an empty string when `use_output_directory` is called without specifying a directory name, keeping it set otherwise. This leads to slightly different behaviour when no file prefix is set but `sim.use_output_directory()` is called (with not arguments). If the script is called `my_script.py` This wil now generate files as `my_script-out/$FILENAME.h5` instead of `my_script-out/my_script-$FILENAME.h5` which seems preferable.